### PR TITLE
Adding window.default-dimensions & fix: better defaults mechanism for config parsing

### DIFF
--- a/src/lib/window.zig
+++ b/src/lib/window.zig
@@ -1,3 +1,4 @@
+const std = @import("std");
 const c = @import("./c.zig");
 const utils = @import("./utils.zig");
 
@@ -42,7 +43,7 @@ pub const Window = struct {
 
     /// Set a default size of the current window instance.
     pub fn setDefaultSize(self: Self, hsize: c_int, vsize: c_int) void {
-        c.gtk_window_set_default_size(self.toRaw, hsize, vsize);
+        c.gtk_window_set_default_size(self.toRaw(), hsize, vsize);
     }
 
     /// Set if the window should be decorated or not.

--- a/src/resources/config.toml
+++ b/src/resources/config.toml
@@ -4,6 +4,7 @@ size = 11
 
 [window]
 padding = 4
+default-dimensions = { x = 800, y = 600 }
 
 [cursor]
 shape = "block"

--- a/src/terminal/init.zig
+++ b/src/terminal/init.zig
@@ -47,6 +47,7 @@ pub fn init(allocator: mem.Allocator, app: *Application) !*Self {
 
     instance.appearance = try AppearanceController.init(
         allocator,
+        &instance.window,
         &instance.terminal,
         &instance.status_text,
     );


### PR DESCRIPTION
This PR adds the new option `window.default-dimensions` which accepts a `x` and a `y` respectively, so the user can change this behavior of the window opening. Also validates the config.font.size value which werent being validated if it's not present in the config file, this is done by marking it as an optional value and adding an orelse statement in each reference of the value itself.

Also the decision of using a Vector struct in the config now is that i'm thinking on reusing the vector structure for others configs options in the future.